### PR TITLE
Multiple board

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -15,11 +15,11 @@ function App() {
   return (
     <MuiThemeProvider theme={theme}>
       <BrowserRouter>
-        <PrivateRoute path="/dashboards" component={DashBoard} />
-        <Route path="/signin" component={SignIn} />
-        <Route path="/signup" component={SignUp} />
+        <PrivateRoute path='/dashboards/:dashboardId' component={DashBoard} />
+        <Route path='/signin' component={SignIn} />
+        <Route path='/signup' component={SignUp} />
         <Route
-          path="/dashboards/:dashboardId/columns/:columnId/tasks/:taskId"
+          path='/dashboards/:dashboardId/columns/:columnId/tasks/:taskId'
           render={props => <CardModal {...props} />}
         />
       </BrowserRouter>

--- a/client/src/AuthService.js
+++ b/client/src/AuthService.js
@@ -33,7 +33,8 @@ const getToken = () => {
 };
 
 const logout = () => {
-  localStorage.clear();
+  localStorage.removeItem("token");
+  localStorage.removeItem("email");
   window.location.href = "/signin";
 };
 
@@ -60,4 +61,12 @@ const _checkStatus = response => {
   });
 };
 
-export { login, loggedIn, logout, authFetch };
+const setCurrentBoard = dashboardId => {
+  localStorage.setItem("dashboard", dashboardId);
+};
+
+const getCurrentBoard = () => {
+  return localStorage.getItem("dashboard");
+};
+
+export { login, loggedIn, logout, authFetch, setCurrentBoard, getCurrentBoard };

--- a/client/src/components/ColumnArea.js
+++ b/client/src/components/ColumnArea.js
@@ -159,7 +159,7 @@ const ColumnArea = props => {
               <CreateColumnButton
                 position='left'
                 noColumn={
-                  taskState.columnOrder === undefined || taskState.columnOrder.length == 0
+                  taskState.columnOrder === undefined || taskState.columnOrder.length === 0
                     ? true
                     : false
                 }
@@ -185,7 +185,7 @@ const ColumnArea = props => {
                 );
               })}
 
-              {taskState.columnOrder === undefined || taskState.columnOrder.length == 0 ? null : (
+              {taskState.columnOrder === undefined || taskState.columnOrder.length === 0 ? null : (
                 <CreateColumnButton position='right' isDraggingOver={snapshot.isDraggingOver} />
               )}
               {provided.placeholder}

--- a/client/src/components/ColumnArea.js
+++ b/client/src/components/ColumnArea.js
@@ -3,13 +3,15 @@ import Column from "./Column";
 import { makeStyles } from "@material-ui/core/styles";
 import { UserContext } from "../userContext";
 import { DragDropContext, Droppable } from "react-beautiful-dnd";
+import { getCurrentBoard, setCurrentBoard } from "../AuthService";
 import { withRouter } from "react-router";
 
 import {
   updateTaskIndexInColumn,
   moveTasksToOther,
   updateColumnIndex,
-  getDashboard
+  getDashboard,
+  getDashboardTitles
 } from "../utils/handleUpdateTasks";
 
 //Component
@@ -20,23 +22,28 @@ import CreateBoardColumn from "./TitleInputModal";
 
 const ColumnArea = props => {
   const classes = useStyles(props);
-  const { value1, dashboardIds } = useContext(UserContext);
+  const { value1, dashboardTitles } = useContext(UserContext);
   let [taskState, setTaskState] = value1;
-  let [dbIds] = dashboardIds;
+  let [dbTitles, setdbTitles] = dashboardTitles;
 
   const [open, setOpen] = useState(false);
 
   let dashboardId = props.match.params.dashboardId;
 
   useEffect(() => {
-    if (!dbIds || dashboardId === "createBoard") {
+    if (Object.entries(dbTitles).length === 0 && dashboardId === "createBoard") {
       setOpen(true);
       return;
     }
+
     getDashboard(dashboardId, res => {
       setTaskState(res);
+      setCurrentBoard(dashboardId);
     });
-  }, [setTaskState]);
+    getDashboardTitles(res => {
+      setdbTitles(res);
+    });
+  }, []);
 
   const onDragEnd = result => {
     const { destination, source, draggableId, type } = result;

--- a/client/src/components/ColumnArea.js
+++ b/client/src/components/ColumnArea.js
@@ -31,7 +31,7 @@ const ColumnArea = props => {
   let dashboardId = props.match.params.dashboardId;
 
   useEffect(() => {
-    if (Object.entries(dbTitles).length === 0 && dashboardId === "createBoard") {
+    if (Object.entries(dbTitles).length === 0 && dashboardId === "createboard") {
       setOpen(true);
       return;
     }
@@ -148,7 +148,7 @@ const ColumnArea = props => {
     setOpen(false);
   };
 
-  if (!taskState || dashboardId === "createBoard") {
+  if (!taskState || dashboardId === "createboard") {
     return <CreateBoardColumn open={open} handleClose={handleClose} dashboard />;
   } else {
     return (

--- a/client/src/components/ColumnArea.js
+++ b/client/src/components/ColumnArea.js
@@ -4,7 +4,6 @@ import { makeStyles } from "@material-ui/core/styles";
 import { UserContext } from "../userContext";
 import { DragDropContext, Droppable } from "react-beautiful-dnd";
 import { withRouter } from "react-router";
-import { authFetch } from "../AuthService";
 
 import {
   updateTaskIndexInColumn,
@@ -21,14 +20,19 @@ import CreateBoardColumn from "./TitleInputModal";
 
 const ColumnArea = props => {
   const classes = useStyles(props);
-  const { value1 } = useContext(UserContext);
+  const { value1, dashboardIds } = useContext(UserContext);
   let [taskState, setTaskState] = value1;
+  let [dbIds] = dashboardIds;
 
   const [open, setOpen] = useState(false);
 
   let dashboardId = props.match.params.dashboardId;
 
   useEffect(() => {
+    if (!dbIds || dashboardId === "createBoard") {
+      setOpen(true);
+      return;
+    }
     getDashboard(dashboardId, res => {
       setTaskState(res);
     });
@@ -137,7 +141,7 @@ const ColumnArea = props => {
     setOpen(false);
   };
 
-  if (!taskState) {
+  if (!taskState || dashboardId === "createBoard") {
     return <CreateBoardColumn open={open} handleClose={handleClose} dashboard />;
   } else {
     return (

--- a/client/src/components/ColumnArea.js
+++ b/client/src/components/ColumnArea.js
@@ -3,7 +3,7 @@ import Column from "./Column";
 import { makeStyles } from "@material-ui/core/styles";
 import { UserContext } from "../userContext";
 import { DragDropContext, Droppable } from "react-beautiful-dnd";
-import { getCurrentBoard, setCurrentBoard } from "../AuthService";
+import { setCurrentBoard } from "../AuthService";
 import { withRouter } from "react-router";
 
 import {
@@ -28,7 +28,7 @@ const ColumnArea = props => {
 
   const [open, setOpen] = useState(false);
 
-  let dashboardId = props.match.params.dashboardId;
+  let dashboardId = taskState._id || props.match.params.dashboardId;
 
   useEffect(() => {
     if (Object.entries(dbTitles).length === 0 && dashboardId === "createboard") {

--- a/client/src/components/ColumnArea.js
+++ b/client/src/components/ColumnArea.js
@@ -148,6 +148,8 @@ const ColumnArea = props => {
     setOpen(false);
   };
 
+  console.log(taskState.columnOrder === undefined || taskState.columnOrder.length == 0);
+
   if (!taskState || dashboardId === "createboard") {
     return <CreateBoardColumn open={open} handleClose={handleClose} dashboard />;
   } else {
@@ -158,7 +160,11 @@ const ColumnArea = props => {
             <div className={classes.root} {...provided.droppableProps} ref={provided.innerRef}>
               <CreateColumnButton
                 position='left'
-                className={classes.bbb}
+                noColumn={
+                  taskState.columnOrder === undefined || taskState.columnOrder.length == 0
+                    ? true
+                    : false
+                }
                 isDraggingOver={snapshot.isDraggingOver}
               />
               {taskState.columnOrder.map((columnId, index) => {
@@ -180,7 +186,10 @@ const ColumnArea = props => {
                   </div>
                 );
               })}
-              <CreateColumnButton position='right' isDraggingOver={snapshot.isDraggingOver} />
+
+              {taskState.columnOrder === undefined || taskState.columnOrder.length == 0 ? null : (
+                <CreateColumnButton position='right' isDraggingOver={snapshot.isDraggingOver} />
+              )}
               {provided.placeholder}
             </div>
           )}

--- a/client/src/components/ColumnArea.js
+++ b/client/src/components/ColumnArea.js
@@ -9,7 +9,8 @@ import { authFetch } from "../AuthService";
 import {
   updateTaskIndexInColumn,
   moveTasksToOther,
-  updateColumnIndex
+  updateColumnIndex,
+  getDashboard
 } from "../utils/handleUpdateTasks";
 
 //Component
@@ -25,18 +26,12 @@ const ColumnArea = props => {
 
   const [open, setOpen] = useState(false);
 
-  let dashboardId = taskState && taskState._id;
+  let dashboardId = props.match.params.dashboardId;
 
   useEffect(() => {
-    authFetch(`/dashboards`)
-      .then(res => {
-        if (res.result) {
-          setTaskState(res.result);
-        }
-      })
-      .catch(() => {
-        setOpen(true);
-      });
+    getDashboard(dashboardId, res => {
+      setTaskState(res);
+    });
   }, [setTaskState]);
 
   const onDragEnd = result => {

--- a/client/src/components/ColumnArea.js
+++ b/client/src/components/ColumnArea.js
@@ -148,8 +148,6 @@ const ColumnArea = props => {
     setOpen(false);
   };
 
-  console.log(taskState.columnOrder === undefined || taskState.columnOrder.length == 0);
-
   if (!taskState || dashboardId === "createboard") {
     return <CreateBoardColumn open={open} handleClose={handleClose} dashboard />;
   } else {

--- a/client/src/components/CreateCard/Comment.js
+++ b/client/src/components/CreateCard/Comment.js
@@ -5,7 +5,7 @@ import BlueButton from "../BlueButton";
 import { CardContext } from "./cardContext";
 import { useHistory } from "react-router-dom";
 
-const Comment = () => {
+const Comment = ({ dashboardId }) => {
   const card = useContext(CardContext);
   const { handleSubmit } = card;
 
@@ -13,26 +13,26 @@ const Comment = () => {
 
   const submitCard = () => {
     handleSubmit();
-    history.push("/dashboards");
+    history.push(`/dashboards/${dashboardId}`);
   };
 
   return (
     <Grid item container>
       <Grid item xs={1}>
-        <ChatBubbleOutlineOutlinedIcon color="primary" />
+        <ChatBubbleOutlineOutlinedIcon color='primary' />
       </Grid>
 
       <Grid item xs={11}>
-        <Typography variant="h3" gutterBottom>
+        <Typography variant='h3' gutterBottom>
           Add comment:
         </Typography>
         <TextField
-          variant="outlined"
-          placeholder="Write a comment..."
+          variant='outlined'
+          placeholder='Write a comment...'
           multiline
           rows={2}
           fullWidth
-          margin="normal"
+          margin='normal'
         />
         <BlueButton mini onClick={submitCard}>
           Save

--- a/client/src/components/CreateCard/Description.js
+++ b/client/src/components/CreateCard/Description.js
@@ -6,35 +6,36 @@ import { useHistory } from "react-router-dom";
 
 import { CardContext } from "./cardContext";
 
-const Description = () => {
+const Description = ({ dashboardId }) => {
   const card = useContext(CardContext);
   const { description, handleDescriptionChange, handleSubmit } = card;
   const history = useHistory();
 
   const submitCard = () => {
     handleSubmit();
-    history.push("/dashboards");
+    console.log("handleSbumit", dashboardId);
+    history.push(`/dashboards/${dashboardId}`);
   };
 
   return (
     <Grid item container>
       <Grid item xs={1}>
-        <MenuBookOutlinedIcon color="primary" />
+        <MenuBookOutlinedIcon color='primary' />
       </Grid>
 
       <Grid item xs={11}>
-        <Typography variant="h3" gutterBottom>
+        <Typography variant='h3' gutterBottom>
           Description:
         </Typography>
         <TextField
-          placeholder="Add description..."
+          placeholder='Add description...'
           value={description}
           onChange={e => handleDescriptionChange(e)}
-          variant="outlined"
+          variant='outlined'
           multiline
           rows={4}
           fullWidth
-          margin="normal"
+          margin='normal'
         />
         <BlueButton onClick={submitCard} mini>
           Save

--- a/client/src/components/CreateCard/Description.js
+++ b/client/src/components/CreateCard/Description.js
@@ -13,7 +13,6 @@ const Description = ({ dashboardId }) => {
 
   const submitCard = () => {
     handleSubmit();
-    console.log("handleSbumit", dashboardId);
     history.push(`/dashboards/${dashboardId}`);
   };
 

--- a/client/src/components/CreateCard/Header.js
+++ b/client/src/components/CreateCard/Header.js
@@ -9,7 +9,7 @@ import { useHistory } from "react-router-dom";
 
 import { CardContext } from "./cardContext";
 
-const Header = () => {
+const Header = ({ dashboardId }) => {
   const card = useContext(CardContext);
   const history = useHistory();
 
@@ -42,27 +42,23 @@ const Header = () => {
   const classes = useStyles();
 
   const handleClose = () => {
-    history.push("/dashboards");
+    history.push(`/dashboards/${dashboardId}`);
     handleCloseCard();
   };
 
   return (
     <Grid item xs={12} className={classes.header}>
-      <IconButton
-        onClick={handleClose}
-        className={classes.closeButton}
-        aria-label="close"
-      >
+      <IconButton onClick={handleClose} className={classes.closeButton} aria-label='close'>
         <CloseIcon />
       </IconButton>
       <Grid item xs={12} container>
         <Grid item xs={1}>
-          <AssignmentOutlinedIcon color="primary" fontSize="large" />
+          <AssignmentOutlinedIcon color='primary' fontSize='large' />
         </Grid>
 
         <Grid item xs={11}>
           <TextField
-            placeholder="Add title..."
+            placeholder='Add title...'
             value={title}
             autoFocus={!title}
             InputProps={{ classes: { input: classes.text } }}
@@ -70,12 +66,8 @@ const Header = () => {
             helperText={error && "Title Required"}
             error={!!error}
           />
-          {openTag ? (
-            <SelectTag />
-          ) : (
-            tag && <Tag onClick={handleOpenTag} color={tag} card />
-          )}
-          <Typography variant="subtitle2" display="block" color="secondary">
+          {openTag ? <SelectTag /> : tag && <Tag onClick={handleOpenTag} color={tag} card />}
+          <Typography variant='subtitle2' display='block' color='secondary'>
             In list "{columnName}"
           </Typography>
         </Grid>

--- a/client/src/components/CreateCard/Modal.js
+++ b/client/src/components/CreateCard/Modal.js
@@ -10,6 +10,7 @@ import { authFetch } from "../../AuthService";
 import { useParams, useHistory } from "react-router-dom";
 import { handleError } from "../../utils/handleAlerts";
 import DeleteModal from "./DeleteModal";
+import { getDashboard } from "../../utils/handleUpdateTasks";
 
 const CardModal = () => {
   const card = useContext(CardContext);
@@ -21,24 +22,22 @@ const CardModal = () => {
     if ((dashboardId, columnId, taskId)) {
       const fetchUrlCard = async () => {
         try {
-          const res = await authFetch("/dashboards");
+          const res = await authFetch(`/dashboards/${dashboardId}`, {
+            method: "POST"
+          });
 
           const column = res.result.columns[columnId]._id;
           const task = res.result.columns[columnId].tasks[taskId]._id;
           const dashboard = res.result._id;
 
-          if (
-            column !== columnId ||
-            task !== taskId ||
-            dashboard !== dashboardId
-          ) {
-            history.push("/dashboards");
+          if (column !== columnId || task !== taskId || dashboard !== dashboardId) {
+            history.push(`/dashboards/${dashboardId}`);
             handleError("cannot access");
           } else {
             fetchCard(taskId, columnId, res.result);
           }
         } catch (e) {
-          history.push("/dashboards");
+          history.push(`/dashboards/${dashboardId}`);
           handleError("cannot access");
         }
       };
@@ -47,7 +46,7 @@ const CardModal = () => {
   }, []);
 
   const handleClose = () => {
-    history.push("/dashboards");
+    history.push(`/dashboards/${dashboardId}`);
     handleCloseCard();
   };
 
@@ -55,21 +54,20 @@ const CardModal = () => {
     <Dialog
       open={openCard}
       onClose={handleClose}
-      aria-labelledby="form-dialog-title"
+      aria-labelledby='form-dialog-title'
       PaperProps={{
         style: { paddingBottom: "3%", height: deadline && "600px" }
-      }}
-    >
+      }}>
       <DialogContent>
         <Grid container spacing={4}>
-          <Header />
+          <Header dashboardId={dashboardId} />
           <Grid item xs={10} container spacing={4}>
-            <Description />
-            <DeleteModal />
-            <Deadline />
-            <Comment />
+            <Description dashboardId={dashboardId} />
+            <DeleteModal dashboardId={dashboardId} />
+            <Deadline dashboardId={dashboardId} />
+            <Comment dashboardId={dashboardId} />
           </Grid>
-          <ButtonList />
+          <ButtonList dashboardId={dashboardId} />
         </Grid>
       </DialogContent>
     </Dialog>

--- a/client/src/components/CreateCard/Modal.js
+++ b/client/src/components/CreateCard/Modal.js
@@ -10,7 +10,6 @@ import { authFetch } from "../../AuthService";
 import { useParams, useHistory } from "react-router-dom";
 import { handleError } from "../../utils/handleAlerts";
 import DeleteModal from "./DeleteModal";
-import { getDashboard } from "../../utils/handleUpdateTasks";
 
 const CardModal = () => {
   const card = useContext(CardContext);

--- a/client/src/components/CreateCard/cardContext.js
+++ b/client/src/components/CreateCard/cardContext.js
@@ -47,7 +47,7 @@ const CardProvider = props => {
 
   const routeChange = (taskId, columnId, dashboardId, hist) => {
     if (!taskId) {
-      hist.push("/dashboards");
+      hist.push(`/dashboards/${dashboardId}`);
     } else {
       let path = `/dashboards/${dashboardId}/columns/${columnId}/tasks/${taskId}`;
       hist.push(path);

--- a/client/src/components/CreateCard/cardContext.js
+++ b/client/src/components/CreateCard/cardContext.js
@@ -81,22 +81,17 @@ const CardProvider = props => {
           description,
           tag
         };
-        console.log(dashboardId);
-        console.log(columnId);
 
         authFetch(`/dashboards/${dashboardId}/columns/${columnId}/tasks`, {
           method: "POST",
           body: JSON.stringify(createTask)
         })
           .then(res => {
-            console.log(res);
-
             updateUser(res);
           })
           .then(() => handleCloseCard())
           .then(() => handleSuccess(`${title} has been saved!`))
           .catch(err => {
-            console.log(err);
             handleError(err);
           });
       } else {

--- a/client/src/components/CreateCard/cardContext.js
+++ b/client/src/components/CreateCard/cardContext.js
@@ -81,14 +81,22 @@ const CardProvider = props => {
           description,
           tag
         };
-        authFetch(`dashboards/${dashboardId}/columns/${columnId}/tasks`, {
+        console.log(dashboardId);
+        console.log(columnId);
+
+        authFetch(`/dashboards/${dashboardId}/columns/${columnId}/tasks`, {
           method: "POST",
           body: JSON.stringify(createTask)
         })
-          .then(res => updateUser(res))
+          .then(res => {
+            console.log(res);
+
+            updateUser(res);
+          })
           .then(() => handleCloseCard())
           .then(() => handleSuccess(`${title} has been saved!`))
           .catch(err => {
+            console.log(err);
             handleError(err);
           });
       } else {
@@ -177,7 +185,7 @@ const CardProvider = props => {
       method: "DELETE"
     })
       .then(res => updateUser(res))
-      .then(history.push("/dashboards"))
+      .then(history.push(`/dashboards/${dashboard._id}`))
       .then(() => handleCloseCard())
       .then(() => handleSuccess(`Task has been deleted`))
       .catch(err => {

--- a/client/src/components/CreateColumnButton.js
+++ b/client/src/components/CreateColumnButton.js
@@ -9,7 +9,7 @@ import { makeStyles } from "@material-ui/core/styles";
 const CreateColumnButton = props => {
   const classes = useStyles(props);
   const [open, setOpen] = useState(false);
-  const { position, isDraggingOver } = props;
+  const { position, isDraggingOver, noColumn } = props;
 
   const handleClose = () => {
     setOpen(false);
@@ -22,7 +22,9 @@ const CreateColumnButton = props => {
   return (
     <div>
       <Card
-        className={isDraggingOver ? classes.isDraggingOver : classes.addColumn}
+        className={
+          isDraggingOver ? classes.isDraggingOver : noColumn ? classes.noColumn : classes.addColumn
+        }
         onClick={handleClickOpen}>
         <CardContent>
           <ControlPoint className={classes.plusIcon} />
@@ -50,6 +52,27 @@ const useStyles = makeStyles({
     opacity: 0,
     cursor: "pointer",
     "&:hover": {
+      opacity: 1,
+      color: "white"
+    }
+  },
+  noColumn: {
+    backgroundColor: "white",
+    minHeight: 100,
+    minWidth: 300,
+    marginLeft: 100,
+    overflow: "hidden",
+    color: "#D3D3D3",
+    lineHeight: "normal",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    alignItems: "center",
+    transition: "0.2s",
+    opacity: 1,
+    cursor: "pointer",
+    "&:hover": {
+      backgroundColor: "#D3D3D3",
       opacity: 1,
       color: "white"
     }

--- a/client/src/components/DropDownMenu.js
+++ b/client/src/components/DropDownMenu.js
@@ -70,7 +70,6 @@ export default function DropDownMenu(props) {
       handleCloseDropDown();
       setCurrentBoard(dashboardId);
       history.push(`/dashboards/${dashboardId}`);
-      handleSuccess(`Dashboard has been loaded!`);
     });
   };
 

--- a/client/src/components/DropDownMenu.js
+++ b/client/src/components/DropDownMenu.js
@@ -22,7 +22,7 @@ export default function DropDownMenu(props) {
   const [openModal, setOpenModal] = useState(false);
   const { value1, dashboardTitles } = useContext(UserContext);
   const [dbTitles] = dashboardTitles;
-  let [taskState, setTaskState] = value1;
+  let [, setTaskState] = value1;
   let history = useHistory();
   let dbTitlesArray = [];
   let dbIdArray = [];

--- a/client/src/components/DropDownMenu.js
+++ b/client/src/components/DropDownMenu.js
@@ -20,7 +20,7 @@ export default function DropDownMenu(props) {
   const open = Boolean(anchorEl);
   const [openModal, setOpenModal] = useState(false);
   const { value1, dashboardTitles } = useContext(UserContext);
-  const [dbTitles, setDbTitles] = dashboardTitles;
+  const [dbTitles] = dashboardTitles;
   let [, setTaskState] = value1;
   let history = useHistory();
   let dbTitlesArray = [];

--- a/client/src/components/DropDownMenu.js
+++ b/client/src/components/DropDownMenu.js
@@ -12,6 +12,7 @@ import TitleInputModal from "../components/TitleInputModal";
 import AccountCircleOutlinedIcon from "@material-ui/icons/AccountCircleOutlined";
 import { logout } from "../AuthService";
 import { makeStyles } from "@material-ui/core/styles";
+import { handleSuccess } from "../utils/handleAlerts";
 
 export default function DropDownMenu(props) {
   const ITEM_HEIGHT = 48;
@@ -21,7 +22,7 @@ export default function DropDownMenu(props) {
   const [openModal, setOpenModal] = useState(false);
   const { value1, dashboardTitles } = useContext(UserContext);
   const [dbTitles] = dashboardTitles;
-  let [, setTaskState] = value1;
+  let [taskState, setTaskState] = value1;
   let history = useHistory();
   let dbTitlesArray = [];
   let dbIdArray = [];
@@ -49,6 +50,7 @@ export default function DropDownMenu(props) {
   const deleteColumnTrigger = () => {
     deleteColumn(dashboardId, columnId, res => {
       setTaskState(res);
+      handleSuccess(`The column has been deleted!`);
     });
     handleCloseDropDown();
   };
@@ -68,6 +70,7 @@ export default function DropDownMenu(props) {
       handleCloseDropDown();
       setCurrentBoard(dashboardId);
       history.push(`/dashboards/${dashboardId}`);
+      handleSuccess(`Dashboard has been loaded!`);
     });
   };
 

--- a/client/src/components/DropDownMenu.js
+++ b/client/src/components/DropDownMenu.js
@@ -5,26 +5,37 @@ import MenuItem from "@material-ui/core/MenuItem";
 import MoreHorizIcon from "@material-ui/icons/MoreHoriz";
 import Typography from "@material-ui/core/Typography";
 import { UserContext } from "../userContext";
-import { deleteColumn } from "../utils/handleUpdateTasks";
-import { logout } from "../AuthService";
-
+import { deleteColumn, getDashboard } from "../utils/handleUpdateTasks";
+import { useHistory } from "react-router-dom";
+import { setCurrentBoard } from "../AuthService";
 import TitleInputModal from "../components/TitleInputModal";
+import AccountCircleOutlinedIcon from "@material-ui/icons/AccountCircleOutlined";
+import { logout } from "../AuthService";
+import { makeStyles } from "@material-ui/core/styles";
 
 export default function DropDownMenu(props) {
   const ITEM_HEIGHT = 48;
+  const { column, blueNav, columnId, dashboardId, title, topNav } = props;
   const [anchorEl, setAnchorEl] = React.useState(null);
   const open = Boolean(anchorEl);
   const [openModal, setOpenModal] = useState(false);
-  const { value1 } = useContext(UserContext);
+  const { value1, dashboardTitles } = useContext(UserContext);
+  const [dbTitles, setDbTitles] = dashboardTitles;
   let [, setTaskState] = value1;
-
-  const { column, blueNav, columnId, dashboardId, title } = props;
+  let history = useHistory();
+  let dbTitlesArray = [];
+  let dbIdArray = [];
   let options = [];
 
   if (column) {
     options = ["Rename", "Delete"];
-  }
-  if (blueNav) {
+  } else if (blueNav) {
+    for (let i = 0; i < dbTitles.length; i++) {
+      dbTitlesArray.push(dbTitles[i].title);
+      dbIdArray.push(dbTitles[i]._id);
+    }
+    options = dbTitlesArray;
+  } else {
     options = ["Logout"];
   }
   const handleClickDropDown = event => {
@@ -47,8 +58,17 @@ export default function DropDownMenu(props) {
     handleCloseDropDown();
   };
 
-  const logoutTrigger = e => {
+  const logoutTrigger = () => {
     logout();
+  };
+
+  const changeDbTrigger = dashboardId => {
+    getDashboard(dashboardId, res => {
+      setTaskState(res);
+      handleCloseDropDown();
+      setCurrentBoard(dashboardId);
+      history.push(`/dashboards/${dashboardId}`);
+    });
   };
 
   const handleClose = () => {
@@ -62,8 +82,18 @@ export default function DropDownMenu(props) {
   const onClickObject = {
     Rename: renameTrigger,
     Delete: deleteColumnTrigger,
-    Logout: logoutTrigger
+    Logout: logoutTrigger,
+    BlueNav: changeDbTrigger
   };
+
+  const useStyles = makeStyles(theme => ({
+    icon: {
+      marginLeft: 50,
+      width: 50,
+      height: 50
+    }
+  }));
+  const classes = useStyles();
 
   return (
     <div>
@@ -71,8 +101,9 @@ export default function DropDownMenu(props) {
         aria-label='more'
         aria-controls='long-menu'
         aria-haspopup='true'
+        className={topNav ? classes.icon : ""}
         onClick={handleClickDropDown}>
-        <MoreHorizIcon />
+        {topNav ? <AccountCircleOutlinedIcon fontSize='large' /> : <MoreHorizIcon />}
       </IconButton>
       <Menu
         id='long-menu'
@@ -86,14 +117,22 @@ export default function DropDownMenu(props) {
             width: 200
           }
         }}>
-        {options.map(option => {
-          let onClick = onClickObject[option];
-          return (
-            <MenuItem key={option} selected={option === "Pyxis"} onClick={e => onClick(e)}>
-              <Typography>{option}</Typography>
-            </MenuItem>
-          );
-        })}
+        {options ? (
+          options.map((option, index) => {
+            let onClick = onClickObject[option] || changeDbTrigger;
+            let UDashboardId = dbIdArray[index];
+            return (
+              <MenuItem
+                key={option}
+                selected={option === "Pyxis"}
+                onClick={() => onClick(UDashboardId)}>
+                <Typography>{option}</Typography>
+              </MenuItem>
+            );
+          })
+        ) : (
+          <h1>no board exist</h1>
+        )}
       </Menu>
       <TitleInputModal
         open={openModal}

--- a/client/src/components/TitleInputModal.js
+++ b/client/src/components/TitleInputModal.js
@@ -12,9 +12,15 @@ import { makeStyles } from "@material-ui/core/styles";
 import CloseIcon from "@material-ui/icons/Close";
 import BlueButton from "./BlueButton";
 
-import { addColumn, addDashboard, updateColumnName } from "../utils/handleUpdateTasks";
+import {
+  addColumn,
+  addDashboard,
+  updateColumnName,
+  getDashboardTitles
+} from "../utils/handleUpdateTasks";
 import { UserContext } from "../userContext";
 import { handleError } from "../utils/handleAlerts";
+import { setCurrentBoard } from "../AuthService";
 
 import { withRouter } from "react-router-dom";
 
@@ -22,8 +28,9 @@ const TitleInputModal = props => {
   const { open, handleClose, position, dashboard, column, columnId, columnTitle } = props;
   const [title, setTitle] = useState(columnTitle);
   const [error, setError] = useState(false);
-  const { value1 } = useContext(UserContext);
+  const { value1, dashboardTitles } = useContext(UserContext);
   let [taskState, setTaskState] = value1;
+  let [, setDbTitles] = dashboardTitles;
   let dashboardId = taskState && taskState._id;
   let history = props.history;
   let btnText = "Create";
@@ -47,8 +54,14 @@ const TitleInputModal = props => {
       addDashboard(title, res => {
         setTaskState(res);
         setTitle("");
-        history.push(`/dashboards/${res._id}`);
+
+        let newDbUrl = res._id;
+        getDashboardTitles(res => {
+          setDbTitles(res);
+        });
+        setCurrentBoard(newDbUrl);
         handleClose(false);
+        history.push(`/dashboards/${newDbUrl}`);
       });
     } else if (column) {
       if (columnTitle === title) {
@@ -65,6 +78,7 @@ const TitleInputModal = props => {
         setTitle("");
         handleClose(false);
       });
+
       handleClose(false);
     } else {
       try {

--- a/client/src/components/TitleInputModal.js
+++ b/client/src/components/TitleInputModal.js
@@ -23,6 +23,7 @@ import { handleError } from "../utils/handleAlerts";
 import { setCurrentBoard } from "../AuthService";
 
 import { withRouter } from "react-router-dom";
+import { handleSuccess } from "../utils/handleAlerts";
 
 const TitleInputModal = props => {
   const { open, handleClose, position, dashboard, column, columnId, columnTitle } = props;
@@ -62,6 +63,7 @@ const TitleInputModal = props => {
         setCurrentBoard(newDbUrl);
         handleClose(false);
         history.push(`/dashboards/${newDbUrl}`);
+        handleSuccess(`${taskState.title} has been created!`);
       });
     } else if (column) {
       if (columnTitle === title) {
@@ -77,6 +79,7 @@ const TitleInputModal = props => {
         setTaskState(res);
         setTitle("");
         handleClose(false);
+        handleSuccess(`the column has been renamed!`);
       });
 
       handleClose(false);
@@ -86,6 +89,7 @@ const TitleInputModal = props => {
           setTaskState(res);
           setTitle("");
           handleClose(false);
+          handleSuccess(`${res.title} has been added!`);
         });
       } catch (err) {
         handleError(err);

--- a/client/src/components/TitleInputModal.js
+++ b/client/src/components/TitleInputModal.js
@@ -67,22 +67,14 @@ const TitleInputModal = props => {
       });
       handleClose(false);
     } else {
-      if (dashboard) {
-        addDashboard(title, res => {
+      try {
+        addColumn(dashboardId, title, position, res => {
           setTaskState(res);
           setTitle("");
           handleClose(false);
         });
-      } else {
-        try {
-          addColumn(dashboardId, title, position, res => {
-            setTaskState(res);
-            setTitle("");
-            handleClose(false);
-          });
-        } catch (err) {
-          handleError(err);
-        }
+      } catch (err) {
+        handleError(err);
       }
     }
   };

--- a/client/src/components/TitleInputModal.js
+++ b/client/src/components/TitleInputModal.js
@@ -25,6 +25,7 @@ const TitleInputModal = props => {
   const { value1 } = useContext(UserContext);
   let [taskState, setTaskState] = value1;
   let dashboardId = taskState && taskState._id;
+  let history = props.history;
   let btnText = "Create";
   let titleText = "";
 
@@ -46,6 +47,7 @@ const TitleInputModal = props => {
       addDashboard(title, res => {
         setTaskState(res);
         setTitle("");
+        history.push(`/dashboards/${res._id}`);
         handleClose(false);
       });
     } else if (column) {

--- a/client/src/components/TitleInputModal.js
+++ b/client/src/components/TitleInputModal.js
@@ -63,7 +63,7 @@ const TitleInputModal = props => {
         setCurrentBoard(newDbUrl);
         handleClose(false);
         history.push(`/dashboards/${newDbUrl}`);
-        handleSuccess(`${taskState.title} has been created!`);
+        handleSuccess(`Dashboard has been created!`);
       });
     } else if (column) {
       if (columnTitle === title) {

--- a/client/src/components/TopNav.js
+++ b/client/src/components/TopNav.js
@@ -23,7 +23,6 @@ const TopNav = () => {
   };
 
   const handleClickOpen = () => {
-    console.log("clicked");
     setOpen(true);
   };
 

--- a/client/src/components/TopNav.js
+++ b/client/src/components/TopNav.js
@@ -11,7 +11,8 @@ import AppBar from "@material-ui/core/AppBar";
 import AddIcon from "@material-ui/icons/Add";
 import TitleInputModal from "../components/TitleInputModal";
 import { UserContext } from "../userContext";
-import AccountCircleOutlinedIcon from "@material-ui/icons/AccountCircleOutlined";
+import DropDownMenu from "./DropDownMenu";
+
 const TopNav = () => {
   const [open, setOpen] = useState(false);
   const { topNavState } = useContext(UserContext);
@@ -22,6 +23,7 @@ const TopNav = () => {
   };
 
   const handleClickOpen = () => {
+    console.log("clicked");
     setOpen(true);
   };
 
@@ -63,14 +65,10 @@ const TopNav = () => {
     wrapper: {
       display: "flex"
     },
-    icon: {
-      width: 18,
-      height: 18,
-      marginRight: 10
-    },
     btn: {
       color: "white",
-      backgroundColor: "#759CFC"
+      backgroundColor: "#759CFC",
+      marginRight: 6000
     },
     profPic: {
       height: 50,
@@ -80,6 +78,7 @@ const TopNav = () => {
     }
   }));
   const classes = useStyles();
+
   return (
     <div>
       <AppBar position='static' className={classes.root}>
@@ -111,7 +110,7 @@ const TopNav = () => {
                 <AddIcon className={classes.icon} />
                 <Typography>Create board</Typography>
               </BlueButton>
-              <AccountCircleOutlinedIcon className={classes.profPic} />
+              <DropDownMenu topNav />
             </div>
           </Grid>
         </Toolbar>

--- a/client/src/pages/SignIn.js
+++ b/client/src/pages/SignIn.js
@@ -1,29 +1,50 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import { Container, TextField, Grid, Typography } from "@material-ui/core";
 import Button from "../components/BlueButton";
 import useStyles from "../themes/AuthStyles";
 import { Link } from "react-router-dom";
-import { login, loggedIn } from "../AuthService";
+import { login, loggedIn, getCurrentBoard } from "../AuthService";
 import { handleError } from "../utils/handleAlerts";
+import { UserContext } from "../userContext";
+import { getDashboardTitles } from "../utils/handleUpdateTasks";
 
 const SignIn = props => {
   const classes = useStyles();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const { dashboardTitles } = useContext(UserContext);
+  let dashboardId;
+  let currentBoard = getCurrentBoard();
+
+  let [dbTitles, setdbTitles] = dashboardTitles;
   const redirect = dashboardId => {
+    console.log(dashboardId);
+
     loggedIn() && props.history.push(`/dashboards/${dashboardId}`);
   };
 
   useEffect(() => {
-    redirect();
-  });
+    console.log("triggered");
+
+    redirect(dashboardId);
+  }, []);
 
   const handleSignIn = e => {
     e.preventDefault();
+
     login("signin", email, password)
       .then(res => {
         //Todo get last board Id user access  from storage
-        redirect(res.dashboardIds[0].toString());
+        getDashboardTitles(res => {
+          setdbTitles(res);
+          dashboardId = res[0]._id;
+          for (const key in res) {
+            if (res[key]._id === currentBoard) {
+              dashboardId = currentBoard;
+            }
+          }
+          redirect(dashboardId);
+        });
       })
       .catch(err => {
         handleError(err);

--- a/client/src/pages/SignIn.js
+++ b/client/src/pages/SignIn.js
@@ -10,8 +10,8 @@ const SignIn = props => {
   const classes = useStyles();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const redirect = () => {
-    loggedIn() && props.history.push("/dashboards");
+  const redirect = dashboardId => {
+    loggedIn() && props.history.push(`/dashboards/${dashboardId}`);
   };
 
   useEffect(() => {
@@ -21,8 +21,9 @@ const SignIn = props => {
   const handleSignIn = e => {
     e.preventDefault();
     login("signin", email, password)
-      .then(() => {
-        redirect();
+      .then(res => {
+        //Todo get last board Id user access  from storage
+        redirect(res.dashboardIds[0].toString());
       })
       .catch(err => {
         handleError(err);
@@ -35,19 +36,19 @@ const SignIn = props => {
       <Grid item xs={12} md={6}>
         <Container className={classes.paper}>
           <div>
-            <Typography variant="h1" className={classes.title}>
+            <Typography variant='h1' className={classes.title}>
               Welcome back!
             </Typography>
 
             <form onSubmit={handleSignIn}>
               <TextField
-                type="email"
-                label="Enter Email"
-                name="email"
+                type='email'
+                label='Enter Email'
+                name='email'
                 value={email}
                 onChange={e => setEmail(e.target.value)}
-                variant="outlined"
-                margin="normal"
+                variant='outlined'
+                margin='normal'
                 fullWidth
                 InputProps={{
                   classes: {
@@ -61,13 +62,13 @@ const SignIn = props => {
               />
 
               <TextField
-                type="password"
-                label="Password"
-                name="password"
+                type='password'
+                label='Password'
+                name='password'
                 value={password}
                 onChange={e => setPassword(e.target.value)}
-                variant="outlined"
-                margin="normal"
+                variant='outlined'
+                margin='normal'
                 fullWidth
                 InputProps={{
                   classes: {
@@ -88,12 +89,12 @@ const SignIn = props => {
         </Container>
 
         <Container className={classes.footer}>
-          <Typography paragraph variant="h3">
+          <Typography paragraph variant='h3'>
             Don't have an account?
           </Typography>
 
-          <Typography variant="h3">
-            <Link to="/signup">Create</Link>
+          <Typography variant='h3'>
+            <Link to='/signup'>Create</Link>
           </Typography>
         </Container>
       </Grid>

--- a/client/src/pages/SignIn.js
+++ b/client/src/pages/SignIn.js
@@ -13,37 +13,41 @@ const SignIn = props => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const { dashboardTitles } = useContext(UserContext);
-  let dashboardId;
-  let currentBoard = getCurrentBoard();
+  let dashboardId = getCurrentBoard() || "createboard";
 
-  let [dbTitles, setdbTitles] = dashboardTitles;
+  let [dbTitles, setDbTitles] = dashboardTitles;
   const redirect = dashboardId => {
-    console.log(dashboardId);
+    console.log("redirectDashboardId", dashboardId);
 
     loggedIn() && props.history.push(`/dashboards/${dashboardId}`);
   };
 
   useEffect(() => {
-    console.log("triggered");
-
+    console.log("useeffect", dashboardId);
     redirect(dashboardId);
-  }, []);
+  }, [setDbTitles]);
 
   const handleSignIn = e => {
     e.preventDefault();
 
     login("signin", email, password)
       .then(res => {
-        //Todo get last board Id user access  from storage
+        if (res.dashboardIds.length === 0) {
+          dashboardId = "createboard";
+          return redirect(dashboardId);
+        }
         getDashboardTitles(res => {
-          setdbTitles(res);
-          dashboardId = res[0]._id;
+          console.log("triggered", res);
+          setDbTitles(res);
           for (const key in res) {
-            if (res[key]._id === currentBoard) {
-              dashboardId = currentBoard;
+            if (res[key]._id === dashboardId) {
+              return redirect(dashboardId);
             }
           }
-          redirect(dashboardId);
+          dashboardId = res[0]._id;
+          console.log("login", dashboardId);
+
+          return redirect(dashboardId);
         });
       })
       .catch(err => {

--- a/client/src/pages/SignIn.js
+++ b/client/src/pages/SignIn.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from "react";
+import React, { useState, useContext } from "react";
 import { Container, TextField, Grid, Typography } from "@material-ui/core";
 import Button from "../components/BlueButton";
 import useStyles from "../themes/AuthStyles";
@@ -15,17 +15,10 @@ const SignIn = props => {
   const { dashboardTitles } = useContext(UserContext);
   let dashboardId = getCurrentBoard() || "createboard";
 
-  let [dbTitles, setDbTitles] = dashboardTitles;
+  let [, setDbTitles] = dashboardTitles;
   const redirect = dashboardId => {
-    console.log("redirectDashboardId", dashboardId);
-
     loggedIn() && props.history.push(`/dashboards/${dashboardId}`);
   };
-
-  useEffect(() => {
-    console.log("useeffect", dashboardId);
-    redirect(dashboardId);
-  }, [setDbTitles]);
 
   const handleSignIn = e => {
     e.preventDefault();
@@ -37,7 +30,6 @@ const SignIn = props => {
           return redirect(dashboardId);
         }
         getDashboardTitles(res => {
-          console.log("triggered", res);
           setDbTitles(res);
           for (const key in res) {
             if (res[key]._id === dashboardId) {
@@ -45,7 +37,6 @@ const SignIn = props => {
             }
           }
           dashboardId = res[0]._id;
-          console.log("login", dashboardId);
 
           return redirect(dashboardId);
         });

--- a/client/src/pages/SignIn.js
+++ b/client/src/pages/SignIn.js
@@ -22,7 +22,6 @@ const SignIn = props => {
 
   const handleSignIn = e => {
     e.preventDefault();
-
     login("signin", email, password)
       .then(res => {
         if (res.dashboardIds.length === 0) {

--- a/client/src/pages/SignUp.js
+++ b/client/src/pages/SignUp.js
@@ -11,7 +11,7 @@ const SignUp = props => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const redirect = () => {
-    loggedIn() && props.history.push("/dashboards/createBoard");
+    loggedIn() && props.history.push("/dashboards/createboard");
   };
 
   useEffect(() => {

--- a/client/src/pages/SignUp.js
+++ b/client/src/pages/SignUp.js
@@ -11,7 +11,7 @@ const SignUp = props => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const redirect = () => {
-    loggedIn() && props.history.push("/dashboards");
+    loggedIn() && props.history.push("/dashboards/createBoard");
   };
 
   useEffect(() => {
@@ -35,19 +35,19 @@ const SignUp = props => {
       <Grid item xs={12} md={6}>
         <Container className={classes.paper}>
           <div>
-            <Typography variant="h1" className={classes.title}>
+            <Typography variant='h1' className={classes.title}>
               Sign up to Kanban
             </Typography>
 
             <form onSubmit={handleSignUp}>
               <TextField
-                type="email"
-                label="Enter Email"
-                name="email"
+                type='email'
+                label='Enter Email'
+                name='email'
                 value={email}
                 onChange={e => setEmail(e.target.value)}
-                variant="outlined"
-                margin="normal"
+                variant='outlined'
+                margin='normal'
                 fullWidth
                 InputProps={{
                   classes: {
@@ -61,13 +61,13 @@ const SignUp = props => {
               />
 
               <TextField
-                type="password"
-                label="Create password"
-                name="password"
+                type='password'
+                label='Create password'
+                name='password'
                 value={password}
                 onChange={e => setPassword(e.target.value)}
-                variant="outlined"
-                margin="normal"
+                variant='outlined'
+                margin='normal'
                 fullWidth
                 InputProps={{
                   classes: {
@@ -89,12 +89,12 @@ const SignUp = props => {
         </Container>
 
         <Container className={classes.footer}>
-          <Typography paragraph variant="h3">
+          <Typography paragraph variant='h3'>
             Already have an account?
           </Typography>
 
-          <Typography variant="h3">
-            <Link to="/signin">Login</Link>
+          <Typography variant='h3'>
+            <Link to='/signin'>Login</Link>
           </Typography>
         </Container>
       </Grid>

--- a/client/src/userContext.js
+++ b/client/src/userContext.js
@@ -6,14 +6,14 @@ export const UserContext = createContext();
 const UserProvider = props => {
   const [taskState, setTaskState] = useState("");
   const [isInDashboard, setIsInDashboard] = useState(true);
-  const [dbIds, setDbIds] = useState([]);
+  const [dbTitles, setDbTitles] = useState({});
 
   return (
     <UserContext.Provider
       value={{
         value1: [taskState, setTaskState],
         topNavState: [isInDashboard, setIsInDashboard],
-        dashboardIds: [dbIds, setDbIds]
+        dashboardTitles: [dbTitles, setDbTitles]
       }}>
       {props.children}
     </UserContext.Provider>

--- a/client/src/userContext.js
+++ b/client/src/userContext.js
@@ -4,7 +4,7 @@ export const UserContext = createContext();
 
 //To Handdle state and comments globally
 const UserProvider = props => {
-  const [taskState, setTaskState] = useState(null);
+  const [taskState, setTaskState] = useState("");
   const [isInDashboard, setIsInDashboard] = useState(true);
   const [dbIds, setDbIds] = useState([]);
 

--- a/client/src/userContext.js
+++ b/client/src/userContext.js
@@ -6,12 +6,14 @@ export const UserContext = createContext();
 const UserProvider = props => {
   const [taskState, setTaskState] = useState(null);
   const [isInDashboard, setIsInDashboard] = useState(true);
+  const [dbIds, setDbIds] = useState([]);
 
   return (
     <UserContext.Provider
       value={{
         value1: [taskState, setTaskState],
-        topNavState: [isInDashboard, setIsInDashboard]
+        topNavState: [isInDashboard, setIsInDashboard],
+        dashboardIds: [dbIds, setDbIds]
       }}>
       {props.children}
     </UserContext.Provider>

--- a/client/src/utils/handleUpdateTasks.js
+++ b/client/src/utils/handleUpdateTasks.js
@@ -2,7 +2,6 @@ import { handleError } from "./handleAlerts";
 import { authFetch } from "../AuthService";
 
 //ToDo remove this after implementing create board function
-
 export const updateTaskIndexInColumn = async (dashboardId, columnId, taskOrder) => {
   let body = { taskOrder };
   authFetch(`/dashboards/${dashboardId}/columns/${columnId}/taskOrder`, {

--- a/client/src/utils/handleUpdateTasks.js
+++ b/client/src/utils/handleUpdateTasks.js
@@ -81,8 +81,6 @@ export const getDashboard = (dashboardId, cb) => {
     dashboardId
   };
 
-  console.log(dashboardId);
-
   authFetch(`/dashboards/${dashboardId}`, {
     method: "post",
     body: JSON.stringify(body)

--- a/client/src/utils/handleUpdateTasks.js
+++ b/client/src/utils/handleUpdateTasks.js
@@ -75,13 +75,8 @@ export const addDashboard = (title, cb) => {
 };
 
 export const getDashboard = (dashboardId, cb) => {
-  let body = {
-    dashboardId
-  };
-
   authFetch(`/dashboards/${dashboardId}`, {
-    method: "post",
-    body: JSON.stringify(body)
+    method: "get"
   })
     .then(res => {
       cb(res.result);
@@ -92,9 +87,7 @@ export const getDashboard = (dashboardId, cb) => {
 };
 
 export const getDashboardTitles = cb => {
-  authFetch(`/dashboards/titles`, {
-    method: "get"
-  })
+  authFetch("/dashboards")
     .then(res => {
       cb(res.result);
     })

--- a/client/src/utils/handleUpdateTasks.js
+++ b/client/src/utils/handleUpdateTasks.js
@@ -71,7 +71,6 @@ export const addDashboard = (title, cb) => {
       cb(res.result);
     })
     .catch(err => {
-      console.log(err);
       handleError(err);
     });
 };
@@ -89,7 +88,6 @@ export const getDashboard = (dashboardId, cb) => {
       cb(res.result);
     })
     .catch(err => {
-      console.log(err);
       handleError(err);
     });
 };

--- a/client/src/utils/handleUpdateTasks.js
+++ b/client/src/utils/handleUpdateTasks.js
@@ -92,6 +92,18 @@ export const getDashboard = (dashboardId, cb) => {
     });
 };
 
+export const getDashboardTitles = cb => {
+  authFetch(`/dashboards/titles`, {
+    method: "get"
+  })
+    .then(res => {
+      cb(res.result);
+    })
+    .catch(err => {
+      handleError(err);
+    });
+};
+
 export const deleteColumn = (dashboardId, columnId, cb) => {
   authFetch(`/dashboards/${dashboardId}/columns/${columnId}`, {
     method: "delete"

--- a/client/src/utils/handleUpdateTasks.js
+++ b/client/src/utils/handleUpdateTasks.js
@@ -3,11 +3,7 @@ import { authFetch } from "../AuthService";
 
 //ToDo remove this after implementing create board function
 
-export const updateTaskIndexInColumn = async (
-  dashboardId,
-  columnId,
-  taskOrder
-) => {
+export const updateTaskIndexInColumn = async (dashboardId, columnId, taskOrder) => {
   let body = { taskOrder };
   authFetch(`/dashboards/${dashboardId}/columns/${columnId}/taskOrder`, {
     method: "put",
@@ -68,6 +64,26 @@ export const addDashboard = (title, cb) => {
   };
 
   authFetch("/dashboards", {
+    method: "post",
+    body: JSON.stringify(body)
+  })
+    .then(res => {
+      cb(res.result);
+    })
+    .catch(err => {
+      console.log(err);
+      handleError(err);
+    });
+};
+
+export const getDashboard = (dashboardId, cb) => {
+  let body = {
+    dashboardId
+  };
+
+  console.log(dashboardId);
+
+  authFetch(`/dashboards/${dashboardId}`, {
     method: "post",
     body: JSON.stringify(body)
   })

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -9,7 +9,8 @@ const UserSchema = new mongoose.Schema({
   password: {
     type: String,
     required: true
-  }
+  },
+  dashboardIds: [{ type: mongoose.Schema.Types.ObjectId, ref: "Dashboard" }]
 });
 
 //hash password on signup

--- a/server/routes/dashBoard.js
+++ b/server/routes/dashBoard.js
@@ -5,6 +5,7 @@ const checkToken = require("../auth/validateToken");
 
 // Models;
 const { Task, Column, Dashboard } = require("../models/Dashboard");
+const { User } = require("../models/User");
 
 //@CreateBoard
 router.get("/", checkToken, async (req, res) => {
@@ -29,6 +30,13 @@ router.get("/", checkToken, async (req, res) => {
 router.post("/", checkToken, async (req, res) => {
   const { title } = req.body;
   let userId = req.decoded.id;
+  console.log(userId);
+
+  let user = User.findOne({ _id: userId });
+
+  if (!user) {
+    return res.status(401).json({ error: "User doesn't exist" });
+  }
 
   if (!title) {
     return res.status(401).json({ error: "Please Enter dashboard title" });
@@ -54,6 +62,11 @@ router.post("/", checkToken, async (req, res) => {
     });
 
     let result = await newDashBoard.save();
+
+    await user.dashboardId.push(result._id);
+    let newData = await user.save();
+    console.log(newData);
+
     res.status(200).json({ result });
   } catch (err) {
     console.log(err);
@@ -108,141 +121,125 @@ router.post("/:dashboardId/columns", checkToken, async (req, res) => {
 });
 
 //delete column @done
-router.delete(
-  "/:dashboardId/columns/:columnId",
-  checkToken,
-  async (req, res) => {
-    const { dashboardId, columnId } = req.params;
-    try {
-      //data manipulation
-      let updateCond = {};
+router.delete("/:dashboardId/columns/:columnId", checkToken, async (req, res) => {
+  const { dashboardId, columnId } = req.params;
+  try {
+    //data manipulation
+    let updateCond = {};
 
-      updateCond["$unset"] = {};
-      updateCond["$unset"]["columns." + columnId] = "";
-      updateCond["$pull"] = {};
-      updateCond["$pull"]["columnOrder"] = columnId;
+    updateCond["$unset"] = {};
+    updateCond["$unset"]["columns." + columnId] = "";
+    updateCond["$pull"] = {};
+    updateCond["$pull"]["columnOrder"] = columnId;
 
-      const result = await updateData(Dashboard, dashboardId, updateCond);
-      res.status(200).json({ result });
-    } catch (err) {
-      console.log(err);
-      res.status(400).json({ error: "Failed to delete column" });
-    }
+    const result = await updateData(Dashboard, dashboardId, updateCond);
+    res.status(200).json({ result });
+  } catch (err) {
+    console.log(err);
+    res.status(400).json({ error: "Failed to delete column" });
   }
-);
+});
 
 // Add a task @Done
-router.post(
-  "/:dashboardId/columns/:columnId/tasks",
-  checkToken,
-  async (req, res) => {
-    const { title, description, deadline, tag, actions, comments } = req.body;
-    const { dashboardId, columnId } = req.params;
+router.post("/:dashboardId/columns/:columnId/tasks", checkToken, async (req, res) => {
+  const { title, description, deadline, tag, actions, comments } = req.body;
+  const { dashboardId, columnId } = req.params;
 
-    try {
-      const newTask = new Task({
-        title,
-        description,
-        tag,
-        deadline,
-        actions,
-        comments
-      });
+  try {
+    const newTask = new Task({
+      title,
+      description,
+      tag,
+      deadline,
+      actions,
+      comments
+    });
 
-      if (!title) {
-        return res.status(401).json({ error: "Please Enter task title" });
-      }
-
-      let newTasks = {};
-      let board = await Dashboard.findOne({ _id: dashboardId });
-      let Column = await board.columns.get(columnId);
-
-      for (const key of Column.tasks.keys()) {
-        let item = Column.tasks.get(key);
-        newTasks[item.id] = item;
-      }
-
-      newTasks = {
-        ...newTasks,
-        [newTask._id]: newTask
-      };
-
-      //data manipulation
-      let updateCond = {};
-      updateCond["$set"] = {};
-      updateCond["$set"]["columns." + columnId + ".tasks"] = newTasks;
-      updateCond["$push"] = {};
-      updateCond["$push"]["columns." + columnId + ".taskOrder"] = newTask._id;
-
-      const result = await updateData(Dashboard, dashboardId, updateCond);
-      res.status(200).json({ result });
-    } catch (err) {
-      console.log(err);
-      res.status(400).json({ error: "Failed to add task" });
+    if (!title) {
+      return res.status(401).json({ error: "Please Enter task title" });
     }
+
+    let newTasks = {};
+    let board = await Dashboard.findOne({ _id: dashboardId });
+    let Column = await board.columns.get(columnId);
+
+    for (const key of Column.tasks.keys()) {
+      let item = Column.tasks.get(key);
+      newTasks[item.id] = item;
+    }
+
+    newTasks = {
+      ...newTasks,
+      [newTask._id]: newTask
+    };
+
+    //data manipulation
+    let updateCond = {};
+    updateCond["$set"] = {};
+    updateCond["$set"]["columns." + columnId + ".tasks"] = newTasks;
+    updateCond["$push"] = {};
+    updateCond["$push"]["columns." + columnId + ".taskOrder"] = newTask._id;
+
+    const result = await updateData(Dashboard, dashboardId, updateCond);
+    res.status(200).json({ result });
+  } catch (err) {
+    console.log(err);
+    res.status(400).json({ error: "Failed to add task" });
   }
-);
+});
 
 //Update card Data
-router.put(
-  "/:dashboardId/columns/:columnId/tasks/:taskId",
-  checkToken,
-  async (req, res) => {
-    try {
-      const { title, description, deadline, comments, tag, action } = req.body;
-      const { dashboardId, columnId, taskId } = req.params;
-
-      if (!title) {
-        return res.status(401).json({ error: "Please Enter task title" });
-      }
-
-      let newTask = {
-        title,
-        description,
-        deadline,
-        comments,
-        tag,
-        action,
-        _id: taskId
-      };
-
-      let updateCond = {};
-      updateCond["$set"] = {};
-      updateCond["$set"]["columns." + columnId + ".tasks." + taskId] = newTask;
-
-      const result = await updateData(Dashboard, dashboardId, updateCond);
-      res.status(200).json({ result });
-    } catch (err) {
-      console.log(err);
-      res.status(400).json({ error: "Failed to update task" });
-    }
-  }
-);
-
-//delete card @done
-router.delete(
-  "/:dashboardId/columns/:columnId/tasks/:taskId",
-  checkToken,
-  async (req, res) => {
+router.put("/:dashboardId/columns/:columnId/tasks/:taskId", checkToken, async (req, res) => {
+  try {
+    const { title, description, deadline, comments, tag, action } = req.body;
     const { dashboardId, columnId, taskId } = req.params;
 
-    try {
-      //data manipulation
-      let updateCond = {};
-      updateCond["$unset"] = {};
-      updateCond["$unset"]["columns." + columnId + ".tasks." + taskId] = "";
-      updateCond["$pull"] = {};
-      updateCond["$pull"]["columns." + columnId + ".taskOrder"] = taskId;
-
-      const result = await updateData(Dashboard, dashboardId, updateCond);
-
-      res.status(200).json({ result });
-    } catch (err) {
-      console.log(err);
-      res.status(400).json({ error: "Failed to delete task" });
+    if (!title) {
+      return res.status(401).json({ error: "Please Enter task title" });
     }
+
+    let newTask = {
+      title,
+      description,
+      deadline,
+      comments,
+      tag,
+      action,
+      _id: taskId
+    };
+
+    let updateCond = {};
+    updateCond["$set"] = {};
+    updateCond["$set"]["columns." + columnId + ".tasks." + taskId] = newTask;
+
+    const result = await updateData(Dashboard, dashboardId, updateCond);
+    res.status(200).json({ result });
+  } catch (err) {
+    console.log(err);
+    res.status(400).json({ error: "Failed to update task" });
   }
-);
+});
+
+//delete card @done
+router.delete("/:dashboardId/columns/:columnId/tasks/:taskId", checkToken, async (req, res) => {
+  const { dashboardId, columnId, taskId } = req.params;
+
+  try {
+    //data manipulation
+    let updateCond = {};
+    updateCond["$unset"] = {};
+    updateCond["$unset"]["columns." + columnId + ".tasks." + taskId] = "";
+    updateCond["$pull"] = {};
+    updateCond["$pull"]["columns." + columnId + ".taskOrder"] = taskId;
+
+    const result = await updateData(Dashboard, dashboardId, updateCond);
+
+    res.status(200).json({ result });
+  } catch (err) {
+    console.log(err);
+    res.status(400).json({ error: "Failed to delete task" });
+  }
+});
 //update ColumnTitle
 router.put("/:dashboardId/columns/:columnId", checkToken, async (req, res) => {
   try {
@@ -266,89 +263,71 @@ router.put("/:dashboardId/columns/:columnId", checkToken, async (req, res) => {
 });
 
 //Update column index @Done
-router.put(
-  "/:dashboardId/columns/:columnId/columnOrder",
-  checkToken,
-  async (req, res) => {
-    try {
-      const { dashboardId } = req.params;
-      const { columnOrder } = req.body;
+router.put("/:dashboardId/columns/:columnId/columnOrder", checkToken, async (req, res) => {
+  try {
+    const { dashboardId } = req.params;
+    const { columnOrder } = req.body;
 
-      //data manipulation
-      let updateCond = {};
-      updateCond["$set"] = {};
-      updateCond["$set"]["columnOrder"] = columnOrder;
+    //data manipulation
+    let updateCond = {};
+    updateCond["$set"] = {};
+    updateCond["$set"]["columnOrder"] = columnOrder;
 
-      const result = await updateData(Dashboard, dashboardId, updateCond);
+    const result = await updateData(Dashboard, dashboardId, updateCond);
 
-      res.status(200).json({ result });
-    } catch (err) {
-      console.log(err);
-      res.status(400).json({ error: "Failed to delete column" });
-    }
+    res.status(200).json({ result });
+  } catch (err) {
+    console.log(err);
+    res.status(400).json({ error: "Failed to delete column" });
   }
-);
+});
 
 //Update task index within same column @Done
-router.put(
-  "/:dashboardId/columns/:columnId/taskOrder",
-  checkToken,
-  async (req, res) => {
-    try {
-      const { taskOrder } = req.body;
-      const { dashboardId, columnId } = req.params;
-
-      //data manipulation
-      let updateCond = {};
-      updateCond["$set"] = {};
-      updateCond["$set"]["columns." + columnId + ".taskOrder"] = taskOrder;
-
-      const result = await updateData(Dashboard, dashboardId, updateCond);
-      res.status(200).json({ result });
-    } catch (err) {
-      console.log(err);
-      res.status(400).json({ error: "Failed to move task" });
-    }
-  }
-);
-
-//Update task index between Column @Done
-router.put(
-  "/:dashboardId/columns/:columnId/taskColumnOrder",
-  checkToken,
-  async (req, res) => {
-    const {
-      columnSourceTasks,
-      columnSourceTaskOrder,
-      columnToSourceId,
-      columnToTasks,
-      columnToTaskOrder
-    } = req.body;
-
+router.put("/:dashboardId/columns/:columnId/taskOrder", checkToken, async (req, res) => {
+  try {
+    const { taskOrder } = req.body;
     const { dashboardId, columnId } = req.params;
 
-    try {
-      let updateCond = {};
-      updateCond["$set"] = {};
-      updateCond["$set"]["columns." + columnId + ".tasks"] = columnSourceTasks;
-      updateCond["$set"][
-        "columns." + columnId + ".taskOrder"
-      ] = columnSourceTaskOrder;
-      updateCond["$set"][
-        "columns." + columnToSourceId + ".tasks"
-      ] = columnToTasks;
-      updateCond["$set"][
-        "columns." + columnToSourceId + ".taskOrder"
-      ] = columnToTaskOrder;
+    //data manipulation
+    let updateCond = {};
+    updateCond["$set"] = {};
+    updateCond["$set"]["columns." + columnId + ".taskOrder"] = taskOrder;
 
-      const result = await updateData(Dashboard, dashboardId, updateCond);
-
-      res.status(200).json({ result });
-    } catch (err) {
-      console.log(err);
-      res.status(400).json({ error: "Failed to move task to the column" });
-    }
+    const result = await updateData(Dashboard, dashboardId, updateCond);
+    res.status(200).json({ result });
+  } catch (err) {
+    console.log(err);
+    res.status(400).json({ error: "Failed to move task" });
   }
-);
+});
+
+//Update task index between Column @Done
+router.put("/:dashboardId/columns/:columnId/taskColumnOrder", checkToken, async (req, res) => {
+  const {
+    columnSourceTasks,
+    columnSourceTaskOrder,
+    columnToSourceId,
+    columnToTasks,
+    columnToTaskOrder
+  } = req.body;
+
+  const { dashboardId, columnId } = req.params;
+
+  try {
+    let updateCond = {};
+    updateCond["$set"] = {};
+    updateCond["$set"]["columns." + columnId + ".tasks"] = columnSourceTasks;
+    updateCond["$set"]["columns." + columnId + ".taskOrder"] = columnSourceTaskOrder;
+    updateCond["$set"]["columns." + columnToSourceId + ".tasks"] = columnToTasks;
+    updateCond["$set"]["columns." + columnToSourceId + ".taskOrder"] = columnToTaskOrder;
+
+    const result = await updateData(Dashboard, dashboardId, updateCond);
+
+    res.status(200).json({ result });
+  } catch (err) {
+    console.log(err);
+    res.status(400).json({ error: "Failed to move task to the column" });
+  }
+});
 
 module.exports = router;

--- a/server/routes/dashBoard.js
+++ b/server/routes/dashBoard.js
@@ -25,6 +25,22 @@ router.get("/", checkToken, async (req, res) => {
   }
 });
 
+//Retrieve specif dashboard
+router.post("/:dashboardId", checkToken, async (req, res) => {
+  let userId = req.decoded.id;
+  let id = req.params.dashboardId;
+  console.log(id);
+
+  try {
+    let result = await Dashboard.findOne({ user: userId, _id: id });
+
+    res.status(200).json({ result });
+  } catch (err) {
+    console.log(err);
+    res.status(404).json({ error: "Dashboard does not exist" });
+  }
+});
+
 //Add Dashboard @Done
 router.post("/", checkToken, async (req, res) => {
   const { title } = req.body;
@@ -64,17 +80,22 @@ router.post("/", checkToken, async (req, res) => {
   }
 });
 
-//delete dashboard @done
+//delete dashboard @To Do delete
 router.delete("/:dashboardId", checkToken, async (req, res) => {
   const { dashboardId } = req.params;
+  let userId = req.decoded.id;
   Dashboard.remove({ _id: dashboardId }, function(err) {
     if (!err) {
       res.status(200).json({ result: "Dashboard deleted" });
     } else {
       console.log(err);
-      res.status(400).json({ error: "Failed to delete dashboard" });
+      return res.status(400).json({ error: "Failed to delete dashboard" });
     }
   });
+  User.findOneAndUpdate(
+    { _id: userId, dashboardIds: dashboardId },
+    { $pull: { dashboardIds: dashboardId } }
+  );
 });
 
 // Add a column @Done
@@ -113,6 +134,7 @@ router.post("/:dashboardId/columns", checkToken, async (req, res) => {
 //delete column @done
 router.delete("/:dashboardId/columns/:columnId", checkToken, async (req, res) => {
   const { dashboardId, columnId } = req.params;
+
   try {
     //data manipulation
     let updateCond = {};

--- a/server/routes/dashBoard.js
+++ b/server/routes/dashBoard.js
@@ -58,6 +58,7 @@ router.get("/titles", checkToken, async (req, res) => {
 router.post("/", checkToken, async (req, res) => {
   const { title } = req.body;
   let userId = req.decoded.id;
+  console.log(userId);
 
   if (!title) {
     return res.status(401).json({ error: "Please Enter dashboard title" });

--- a/server/routes/dashBoard.js
+++ b/server/routes/dashBoard.js
@@ -40,6 +40,20 @@ router.post("/:dashboardId", checkToken, async (req, res) => {
   }
 });
 
+//@get dashboard titles
+router.get("/titles", checkToken, async (req, res) => {
+  let userId = req.decoded.id;
+
+  try {
+    let result = await Dashboard.find({ user: userId }).select("title");
+
+    res.status(200).json({ result });
+  } catch (err) {
+    console.log(err);
+    res.status(404).json({ error: "Dashboard does not exist" });
+  }
+});
+
 //Add Dashboard @Done
 router.post("/", checkToken, async (req, res) => {
   const { title } = req.body;

--- a/server/routes/dashBoard.js
+++ b/server/routes/dashBoard.js
@@ -5,7 +5,7 @@ const checkToken = require("../auth/validateToken");
 
 // Models;
 const { Task, Column, Dashboard } = require("../models/Dashboard");
-const { User } = require("../models/User");
+const User = require("../models/User");
 
 //@CreateBoard
 router.get("/", checkToken, async (req, res) => {
@@ -29,13 +29,6 @@ router.get("/", checkToken, async (req, res) => {
 router.post("/", checkToken, async (req, res) => {
   const { title } = req.body;
   let userId = req.decoded.id;
-  console.log(userId);
-
-  let user = User.findOne({ _id: userId });
-
-  if (!user) {
-    return res.status(401).json({ error: "User doesn't exist" });
-  }
 
   if (!title) {
     return res.status(401).json({ error: "Please Enter dashboard title" });
@@ -62,9 +55,7 @@ router.post("/", checkToken, async (req, res) => {
 
     let result = await newDashBoard.save();
 
-    await user.dashboardId.push(result._id);
-    let newData = await user.save();
-    console.log(newData);
+    await User.findOneAndUpdate({ _id: userId }, { $push: { dashboardIds: result._id } });
 
     res.status(200).json({ result });
   } catch (err) {

--- a/server/routes/dashBoard.js
+++ b/server/routes/dashBoard.js
@@ -58,7 +58,6 @@ router.get("/titles", checkToken, async (req, res) => {
 router.post("/", checkToken, async (req, res) => {
   const { title } = req.body;
   let userId = req.decoded.id;
-  console.log(userId);
 
   if (!title) {
     return res.status(401).json({ error: "Please Enter dashboard title" });

--- a/server/routes/dashBoard.js
+++ b/server/routes/dashBoard.js
@@ -25,11 +25,10 @@ router.get("/", checkToken, async (req, res) => {
   }
 });
 
-//Retrieve specif dashboard
+//Retrieve specific dashboard
 router.post("/:dashboardId", checkToken, async (req, res) => {
   let userId = req.decoded.id;
   let id = req.params.dashboardId;
-  console.log(id);
 
   try {
     let result = await Dashboard.findOne({ user: userId, _id: id });

--- a/server/routes/dashBoard.js
+++ b/server/routes/dashBoard.js
@@ -8,25 +8,25 @@ const { Task, Column, Dashboard } = require("../models/Dashboard");
 const User = require("../models/User");
 
 //@CreateBoard
-router.get("/", checkToken, async (req, res) => {
-  let userId = req.decoded.id;
+// router.get("/", checkToken, async (req, res) => {
+//   let userId = req.decoded.id;
 
-  try {
-    let result = await Dashboard.findOne({ user: userId });
+//   try {
+//     let result = await Dashboard.findOne({ user: userId });
 
-    if (result) {
-      res.status(200).json({ result });
-    } else {
-      res.status(404).json({ error: "no dashboard" });
-    }
-  } catch (err) {
-    console.log(err);
-    res.status(404).json({ error: "Failed to get dashboard" });
-  }
-});
+//     if (result) {
+//       res.status(200).json({ result });
+//     } else {
+//       res.status(404).json({ error: "no dashboard" });
+//     }
+//   } catch (err) {
+//     console.log(err);
+//     res.status(404).json({ error: "Failed to get dashboard" });
+//   }
+// });
 
 //Retrieve specific dashboard
-router.post("/:dashboardId", checkToken, async (req, res) => {
+router.get("/:dashboardId", checkToken, async (req, res) => {
   let userId = req.decoded.id;
   let id = req.params.dashboardId;
 
@@ -41,9 +41,8 @@ router.post("/:dashboardId", checkToken, async (req, res) => {
 });
 
 //@get dashboard titles
-router.get("/titles", checkToken, async (req, res) => {
+router.get("/", checkToken, async (req, res) => {
   let userId = req.decoded.id;
-
   try {
     let result = await Dashboard.find({ user: userId }).select("title");
 

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -60,7 +60,7 @@ router.post("/signin", validationRules(), validate, async (req, res) => {
     //Create JWT with user ID
     jwt.sign(payload, process.env.JWT_SECRET_KEY, { expiresIn: 36000000 }, (err, token) => {
       if (err) throw err;
-      res.status(200).json({ token });
+      res.status(200).json({ token, dashboardIds: user.dashboardIds });
     });
   } catch (err) {
     console.log(err.message);

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -17,7 +17,7 @@ router.post("/signup", validationRules(), validate, async (req, res) => {
       res.status(400).json({ error: "Email already exists" });
     }
 
-    user = await User.create({ email, password });
+    user = await User.create({ email, password, dashboardIds: [] });
 
     //Save user
     const payload = {


### PR DESCRIPTION
Updated path of FE and logic for redirect to implement multiple boards.
Since this change affects many sections, please review it carefully.
Especially, Sign in and Sign up logic need review.
I spent more time to debug than usual,  but there might be some issues.


Here are the major changes on this pr
-User can select dashboard by clicking three dots on the blue nav
-Added dashboard Id to local storage to save the latest dashboard user accessed. Because of this, the user can access the board he used before he logout.
-Add a drop-down menu to the user icon on the top bar. he can logout from here.
-Displayed Add column button if there is no column on the board